### PR TITLE
feat: 编辑模式多步撤回与一键去背景单步撤回

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -185,6 +185,24 @@ export default function Home() {
   // 新增：横屏设备弹窗状态
   const [showDesktopModal, setShowDesktopModal] = useState<boolean>(false);
 
+  // 新增：编辑撤回历史栈（多步）
+  interface EditSnapshot {
+    mappedPixelData: MappedPixel[][];
+    colorCounts: { [key: string]: { count: number; color: string } };
+    totalBeadCount: number;
+  }
+  const [editHistory, setEditHistory] = useState<EditSnapshot[]>([]);
+
+  // 新增：一键去背景撤回快照（单步）
+  const [bgRemovalSnapshot, setBgRemovalSnapshot] = useState<EditSnapshot | null>(null);
+
+  // 新增：轻量提示
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const showToast = useCallback((msg: string) => {
+    setToastMessage(msg);
+    setTimeout(() => setToastMessage(null), 2000);
+  }, []);
+
   // 放大镜切换处理函数
   const handleToggleMagnifier = () => {
     const newActiveState = !isMagnifierActive;
@@ -205,38 +223,80 @@ export default function Home() {
     setActiveFloatingTool('magnifier');
   };
 
+  // --- 撤回功能 ---
+
+  // 保存编辑快照到历史栈
+  const saveEditSnapshot = useCallback(() => {
+    if (!mappedPixelData || !colorCounts) return;
+    const snapshot: EditSnapshot = {
+      mappedPixelData: mappedPixelData.map(row => row.map(cell => ({ ...cell }))),
+      colorCounts: { ...colorCounts },
+      totalBeadCount,
+    };
+    setEditHistory(prev => [...prev.slice(-49), snapshot]);
+  }, [mappedPixelData, colorCounts, totalBeadCount]);
+
+  // 编辑模式多步撤回
+  const handleUndoEdit = useCallback(() => {
+    if (editHistory.length === 0) return;
+    const snapshot = editHistory[editHistory.length - 1];
+    setMappedPixelData(snapshot.mappedPixelData);
+    setColorCounts(snapshot.colorCounts);
+    setTotalBeadCount(snapshot.totalBeadCount);
+    setEditHistory(prev => prev.slice(0, -1));
+    showToast('已撤回上一步');
+  }, [editHistory, showToast]);
+
+  // 一键去背景单步撤回
+  const handleUndoBgRemoval = useCallback(() => {
+    if (!bgRemovalSnapshot) return;
+    setMappedPixelData(bgRemovalSnapshot.mappedPixelData);
+    setColorCounts(bgRemovalSnapshot.colorCounts);
+    setTotalBeadCount(bgRemovalSnapshot.totalBeadCount);
+    setBgRemovalSnapshot(null);
+    showToast('已撤回背景去除');
+  }, [bgRemovalSnapshot, showToast]);
+
+  // 清空编辑历史（参数变化、退出编辑模式等时调用）
+  const clearEditHistory = useCallback(() => {
+    setEditHistory([]);
+  }, []);
+
   // 放大镜像素编辑处理函数
   const handleMagnifierPixelEdit = (row: number, col: number, colorData: { key: string; color: string }) => {
     if (!mappedPixelData) return;
-    
+
+    const oldPixel = mappedPixelData[row][col];
+    if (!oldPixel || oldPixel.key === colorData.key) return;
+
     // 创建新的像素数据
     const newMappedPixelData = mappedPixelData.map((rowData, r) =>
       rowData.map((pixel, c) => {
         if (r === row && c === col) {
-          return { 
-            key: colorData.key, 
-            color: colorData.color 
+          return {
+            key: colorData.key,
+            color: colorData.color
           } as MappedPixel;
         }
         return pixel;
       })
     );
-    
+
+    saveEditSnapshot();
     setMappedPixelData(newMappedPixelData);
-    
+
     // 更新颜色统计
     if (colorCounts) {
       const newColorCounts = { ...colorCounts };
-      
+
       // 减少原颜色的计数
-      const oldPixel = mappedPixelData[row][col];
       if (newColorCounts[oldPixel.key]) {
         newColorCounts[oldPixel.key].count--;
         if (newColorCounts[oldPixel.key].count === 0) {
           delete newColorCounts[oldPixel.key];
         }
       }
-      
+
       // 增加新颜色的计数
       if (newColorCounts[colorData.key]) {
         newColorCounts[colorData.key].count++;
@@ -246,9 +306,9 @@ export default function Home() {
           color: colorData.color
         };
       }
-      
+
       setColorCounts(newColorCounts);
-      
+
       // 更新总计数
       const newTotal = Object.values(newColorCounts).reduce((sum, item) => sum + item.count, 0);
       setTotalBeadCount(newTotal);
@@ -988,6 +1048,13 @@ export default function Home() {
     setSelectedColor(null);
   }; // 正确闭合 pixelateImage 函数
 
+  // 当 remapTrigger 变化时清空撤回历史（参数调整/颜色排除/新图上传等均会触发 remap）
+  useEffect(() => {
+    clearEditHistory();
+    setBgRemovalSnapshot(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [remapTrigger]);
+
   // 修改useEffect中的pixelateImage调用，加入模式参数
   useEffect(() => {
     if (originalImageSrc && activeBeadPalette.length > 0) {
@@ -1231,6 +1298,8 @@ export default function Home() {
         // ++ Exit manual mode if colors are excluded/included ++
         setIsManualColoringMode(false);
         setSelectedColor(null);
+        clearEditHistory();
+        setBgRemovalSnapshot(null);
     };
 
   // 一键去背景：识别边缘主色并洪水填充去除
@@ -1239,6 +1308,15 @@ export default function Home() {
       alert('请先生成图纸后再使用一键去背景。');
       return;
     }
+
+    // 保存快照用于单步撤回
+    setBgRemovalSnapshot({
+      mappedPixelData: mappedPixelData.map(row => row.map(cell => ({ ...cell }))),
+      colorCounts: colorCounts ? { ...colorCounts } : {},
+      totalBeadCount,
+    });
+    // 去背景会大幅改变数据，清空编辑撤回历史
+    setEditHistory([]);
 
     const { N, M } = gridDimensions;
     const borderCounts = new Map<string, number>();
@@ -1378,8 +1456,9 @@ export default function Home() {
     }
     
     // 更新状态
+    saveEditSnapshot();
     setMappedPixelData(newPixelData);
-    
+
     // 重新计算颜色统计
     if (colorCounts) {
       const newColorCounts: { [hexKey: string]: { count: number; color: string } } = {};
@@ -1487,6 +1566,7 @@ export default function Home() {
 
         // Only update if state changes
         if (newCellData.key !== previousKey || newCellData.isExternal !== wasExternal) {
+          saveEditSnapshot();
           newPixelData[j][i] = newCellData;
           setMappedPixelData(newPixelData);
 
@@ -1821,6 +1901,7 @@ export default function Home() {
 
     if (replaceCount > 0) {
       // 更新像素数据
+      saveEditSnapshot();
       setMappedPixelData(newPixelData);
 
       // 重新计算颜色统计
@@ -1882,6 +1963,7 @@ export default function Home() {
     <>
     {/* 添加自定义动画样式 */}
     <style dangerouslySetInnerHTML={{ __html: floatAnimation }} />
+    <style dangerouslySetInnerHTML={{ __html: '@keyframes toastFadeInOut{0%{opacity:0;transform:translate(-50%,10px)}15%{opacity:1;transform:translate(-50%,0)}85%{opacity:1;transform:translate(-50%,0)}100%{opacity:0;transform:translate(-50%,-10px)}}' }} />
     
     {/* PWA 安装按钮 */}
     <InstallPWA />
@@ -2245,6 +2327,13 @@ export default function Home() {
                     className="inline-flex items-center justify-center h-9 px-3 text-sm rounded-md border border-blue-200 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-200 hover:bg-blue-100 dark:hover:bg-blue-800/40 transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
                   >
                     一键去背景
+                  </button>
+                  <button
+                    onClick={handleUndoBgRemoval}
+                    disabled={!bgRemovalSnapshot}
+                    className="inline-flex items-center justify-center h-9 px-3 text-sm rounded-md border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+                  >
+                    回撤上一步
                   </button>
                 </div>
 
@@ -2614,6 +2703,7 @@ export default function Home() {
           setHighlightColorKey(null);
           setIsMagnifierActive(false);
           setMagnifierSelectionArea(null);
+          clearEditHistory();
         }}
         onToggleMagnifier={handleToggleMagnifier}
         isMagnifierActive={isMagnifierActive}
@@ -2639,6 +2729,8 @@ export default function Home() {
           onToggleOpen={() => setIsFloatingPaletteOpen(!isFloatingPaletteOpen)}
           isActive={activeFloatingTool === 'palette'}
           onActivate={handleActivatePalette}
+          canUndo={editHistory.length > 0}
+          onUndo={handleUndoEdit}
         />
       )}
 
@@ -2719,6 +2811,14 @@ export default function Home() {
         gridDimensions={gridDimensions}
         selectedColorSystem={selectedColorSystem}
       />
+
+      {/* 轻量提示 Toast */}
+      {toastMessage && (
+        <div className="fixed bottom-20 left-1/2 transform -translate-x-1/2 bg-gray-800 text-white px-4 py-2 rounded-lg shadow-lg z-[200] text-sm whitespace-nowrap"
+             style={{ animation: 'toastFadeInOut 2s ease-in-out' }}>
+          {toastMessage}
+        </div>
+      )}
     </div>
    </>
   );

--- a/src/components/FloatingColorPalette.tsx
+++ b/src/components/FloatingColorPalette.tsx
@@ -24,6 +24,8 @@ interface FloatingColorPaletteProps {
   onToggleOpen: () => void;
   isActive: boolean;
   onActivate: () => void;
+  canUndo: boolean;
+  onUndo: () => void;
 }
 
 const FloatingColorPalette: React.FC<FloatingColorPaletteProps> = ({
@@ -43,7 +45,9 @@ const FloatingColorPalette: React.FC<FloatingColorPaletteProps> = ({
   isOpen,
   onToggleOpen,
   isActive,
-  onActivate
+  onActivate,
+  canUndo,
+  onUndo
 }) => {
   // 计算初始位置，确保左边缘在屏幕内（小屏幕时右边缘可以超出）
   const getInitialPosition = () => ({
@@ -231,6 +235,18 @@ const FloatingColorPalette: React.FC<FloatingColorPaletteProps> = ({
 
           {/* 工具按钮行 */}
           <div className="flex gap-2 mb-3">
+            {/* 撤回按钮 */}
+            <button
+              onClick={onUndo}
+              disabled={!canUndo}
+              className="p-2 rounded-lg border transition-all duration-200 flex items-center justify-center text-xs bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-40 disabled:cursor-not-allowed"
+              title="撤回上一步"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h10a5 5 0 015 5v2M3 10l4-4M3 10l4 4" />
+              </svg>
+            </button>
+
             {/* 橡皮擦按钮 */}
             <button
               onClick={() => handleColorClick({ key: TRANSPARENT_KEY, color: '#FFFFFF' })}


### PR DESCRIPTION
## 描述

实现了编辑模式下的多步撤回功能与一键去背景的单步撤回功能。编辑模式下所有操作（单点上色、橡皮擦、区域擦除、批量替换、放大镜编辑）均可多步撤回；一键去背景支持单步撤回。无历史记录时撤回按钮自动禁用，撤回成功后显示轻量 toast 提示。
解决issue #18 

## 改动内容

### page.tsx
- 新增 `EditSnapshot` 接口和 `editHistory` 状态（历史栈，上限 50 步）
- 新增 `bgRemovalSnapshot` 状态（去背景单步快照）
- 新增 `toastMessage` 状态和 `showToast()` 轻量提示函数
- 新增 `saveEditSnapshot()` — 操作前深拷贝当前状态入栈
- 新增 `handleUndoEdit()` — 弹出栈顶快照恢复状态
- 新增 `handleUndoBgRemoval()` — 恢复去背景前状态
- 新增 `clearEditHistory()` — 清空编辑历史
- 在 5 处编辑操作前保存快照：放大镜编辑、区域擦除、单点上色/橡皮擦、批量替换
- 在 `handleAutoRemoveBackground` 前保存去背景快照
- 新增 `useEffect([remapTrigger])` 监听参数变化自动清空历史
- 退出编辑模式、颜色排除/恢复时清空历史
- 在「一键去背景」旁新增「回撤上一步」按钮
- 新增底部 toast UI 及 `toastFadeInOut` 动画

### FloatingColorPalette.tsx
- 新增 `canUndo` / `onUndo` props
- 在工具按钮行最左侧新增撤回按钮（逆时针箭头图标）
- 无历史时按钮自动禁用

## 交互细节

- **编辑撤回**：可连续撤回多步直至历史栈为空，按钮在无历史时禁用
- **去背景撤回**：仅保存最近一次去背景的快照，再次去背景会覆盖旧快照
- **历史清空时机**：调参（粒度/相似度/处理模式）、换图、颜色排除/恢复、退出编辑模式、一键去背景（清编辑历史）
- **Toast 提示**：撤回成功后底部居中显示「已撤回上一步」或「已撤回背景去除」，2 秒后自动消失

## 测试情况

- ✅ TypeScript 类型检查通过
- ✅ Next.js 构建成功
- ✅ 编辑模式多步撤回：单点上色 → 区域擦除 → 批量替换 → 连续撤回
- ✅ 去背景撤回：去背景 → 撤回 → 恢复 → 再次去背景 → 撤回
- ✅ 按钮禁用态：无历史时撤回按钮不可点击
- ✅ 历史清空：调参后编辑历史清空，去背景快照清空
- ✅ 放大镜编辑纳入撤回范围
- ✅ Toast 提示正常显示和消失

## 截图
1. 调色盘中的撤回按钮位置
<img width="493" height="566" alt="image" src="https://github.com/user-attachments/assets/00ae22e3-231b-41e1-9822-805461fe835c" />

2. 一键去背景旁的「回撤上一步」按钮位置
<img width="500" height="123" alt="image" src="https://github.com/user-attachments/assets/61e19d73-0fe4-47f5-b695-7bf7a21b6eaf" />

3. 撤回后的 toast 提示
<img width="500" height="270" alt="image" src="https://github.com/user-attachments/assets/d1d9f558-d88d-4dc5-b9dd-69ca86b55511" />


## 技术说明

- 快照使用深拷贝（`map(row => map(cell => ({...cell})))`），确保状态独立
- 历史栈上限 50 步，防止长时间编辑导致内存增长
- 编辑撤回与去背景撤回使用独立的状态，互不干扰
- 去背景时主动清空编辑历史，因为数据已发生根本变化

---

感谢审阅！如有任何问题或需要调整的地方，请随时告诉我。
