### PR TITLE
feat: hide white cell labels in downloads

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -140,6 +140,7 @@ export default function Home() {
     gridInterval: 10,
     showCoordinates: true,
     showCellNumbers: true,
+    hideWhiteCellNumbers: false,
     gridLineColor: gridLineColorOptions[0].value,
     includeStats: true, // 默认包含统计信息
     exportCsv: false // 默认不导出CSV

--- a/src/components/DownloadSettingsModal.tsx
+++ b/src/components/DownloadSettingsModal.tsx
@@ -167,6 +167,28 @@ const DownloadSettingsModal: React.FC<DownloadSettingsModalProps> = ({
                 <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
               </label>
             </div>
+
+            {tempOptions.showCellNumbers && (
+              <div className="flex items-center justify-between">
+                <div className="flex flex-col">
+                  <label className="flex items-center text-sm font-medium text-gray-700 dark:text-gray-300">
+                    隐藏白色色号
+                  </label>
+                  <span className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    仅隐藏白色格内的 T01/L14 等文字
+                  </span>
+                </div>
+                <label className="relative inline-flex items-center cursor-pointer">
+                  <input
+                    type="checkbox"
+                    className="sr-only peer"
+                    checked={Boolean(tempOptions.hideWhiteCellNumbers)}
+                    onChange={(e) => handleOptionChange('hideWhiteCellNumbers', e.target.checked)}
+                  />
+                  <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+                </label>
+              </div>
+            )}
             
             {/* 添加: 包含色号统计选项 */}
             <div className="flex items-center justify-between">

--- a/src/types/downloadTypes.ts
+++ b/src/types/downloadTypes.ts
@@ -4,6 +4,7 @@ export type GridDownloadOptions = {
   gridInterval: number;
   showCoordinates: boolean;
   showCellNumbers: boolean;
+  hideWhiteCellNumbers: boolean;
   gridLineColor: string;
   includeStats: boolean;
   exportCsv: boolean; // 新增：是否同时导出CSV hex数据

--- a/src/utils/imageDownloader.ts
+++ b/src/utils/imageDownloader.ts
@@ -239,7 +239,7 @@ export async function downloadImage({
     const downloadCellSize = 30;
   
     // 从下载选项中获取设置
-    const { showGrid, gridInterval, showCoordinates, gridLineColor, includeStats, showCellNumbers = true } = options;
+    const { showGrid, gridInterval, showCoordinates, gridLineColor, includeStats, showCellNumbers = true, hideWhiteCellNumbers = false } = options;
   
     // 设置边距空间用于坐标轴标注（如果需要）
     const axisLabelSize = showCoordinates ? Math.max(30, Math.floor(downloadCellSize)) : 0;
@@ -567,7 +567,9 @@ export async function downloadImage({
           ctx.fillStyle = cellColor;
           ctx.fillRect(drawX, drawY, downloadCellSize, downloadCellSize);
 
-          if (showCellNumbers) {
+          const shouldDrawCellNumber = showCellNumbers && !(hideWhiteCellNumbers && cellColor.toUpperCase() === '#FFFFFF');
+
+          if (shouldDrawCellNumber) {
             const cellKey = getDisplayColorKey(cellData.color || '#FFFFFF', selectedColorSystem);
             ctx.fillStyle = getContrastColor(cellColor);
             ctx.fillText(cellKey, drawX + downloadCellSize / 2, drawY + downloadCellSize / 2);


### PR DESCRIPTION
## Summary
- add a download setting to hide labels for white cells only
- keep other cell labels, grid, coordinates, stats, and CSV export behavior unchanged
- skip drawing the label when the mapped cell color is `#FFFFFF`

Fixes #20

## Testing
- npm run lint
- npm run build
- verified local page responds with HTTP 200