### PR TITLE
fix: use pointer cursor for interactive controls

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,18 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+button:not(:disabled),
+[role="button"]:not([aria-disabled="true"]) {
+  cursor: pointer;
+}
+
+button:disabled,
+[role="button"][aria-disabled="true"] {
+  cursor: not-allowed;
+}
+
+label:has(input[type="checkbox"]),
+label:has(input[type="radio"]) {
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- make enabled buttons and role=button controls use the pointer cursor
- make disabled interactive controls use the not-allowed cursor
- make checkbox/radio labels show pointer affordance when hovered

Fixes #12

## Testing
- npm run lint
- npm run build
- verified local page responds with HTTP 200
- verified enabled button computed cursor is `pointer` in browser