### PR TITLE
fix: preserve transparent cells when importing csv

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -583,10 +583,9 @@ export default function Home() {
     // 绘制每个像素
     pixelData.forEach((row, rowIndex) => {
       row.forEach((cell, colIndex) => {
-        if (cell) {
-          // 使用颜色，外部单元格用白色
-          const color = cell.isExternal ? '#FFFFFF' : cell.color;
-          ctx.fillStyle = color;
+        if (cell && !cell.isExternal) {
+          // Keep external cells transparent in the synthetic PNG.
+          ctx.fillStyle = cell.color;
           ctx.fillRect(
             colIndex * pixelSize, 
             rowIndex * pixelSize, 

--- a/src/components/CompletionCard.tsx
+++ b/src/components/CompletionCard.tsx
@@ -32,7 +32,8 @@ const CompletionCard: React.FC<CompletionCardProps> = ({
       for (let col = 0; col < gridDimensions.N; col++) {
         const pixel = mappedPixelData[row][col];
         // 排除透明色和空白区域
-        if (pixel.color && 
+        if (!pixel.isExternal &&
+            pixel.color &&
             pixel.color !== 'transparent' && 
             pixel.color !== 'rgba(0,0,0,0)' &&
             !pixel.color.includes('rgba(0, 0, 0, 0)')) {
@@ -89,13 +90,15 @@ const CompletionCard: React.FC<CompletionCardProps> = ({
     for (let row = 0; row < gridDimensions.M; row++) {
       for (let col = 0; col < gridDimensions.N; col++) {
         const pixel = mappedPixelData[row][col];
-        ctx.fillStyle = pixel.color;
-        ctx.fillRect(
-          col * cellWidth,
-          row * cellHeight,
-          cellWidth,
-          cellHeight
-        );
+        if (!pixel.isExternal) {
+          ctx.fillStyle = pixel.color;
+          ctx.fillRect(
+            col * cellWidth,
+            row * cellHeight,
+            cellWidth,
+            cellHeight
+          );
+        }
       }
     }
 
@@ -522,4 +525,4 @@ const CompletionCard: React.FC<CompletionCardProps> = ({
   );
 };
 
-export default CompletionCard; 
+export default CompletionCard;

--- a/src/utils/imageDownloader.ts
+++ b/src/utils/imageDownloader.ts
@@ -1,6 +1,7 @@
 import { GridDownloadOptions } from '../types/downloadTypes';
 import { MappedPixel, PaletteColor } from './pixelation';
 import { getDisplayColorKey, getColorKeyByHex, ColorSystem } from './colorSystemUtils';
+import { transparentColorData } from './pixelEditingUtils';
 
 // 用于获取对比色的工具函数 - 从page.tsx复制
 function getContrastColor(hex: string): string {
@@ -153,14 +154,11 @@ export function importCsvData(file: File): Promise<{
           
           for (let col = 0; col < N; col++) {
             const cellValue = rowData[col].trim();
+            const normalizedCellValue = cellValue.toUpperCase();
             
-            if (cellValue === 'TRANSPARENT' || cellValue === '') {
+            if (normalizedCellValue === 'TRANSPARENT' || cellValue === '') {
               // 外部/透明单元格
-              mappedRow.push({
-                key: 'TRANSPARENT',
-                color: '#FFFFFF',
-                isExternal: true
-              });
+              mappedRow.push({ ...transparentColorData });
             } else {
               // 验证hex颜色格式
               const hexPattern = /^#[0-9A-Fa-f]{6}$/;
@@ -171,8 +169,8 @@ export function importCsvData(file: File): Promise<{
               
               // 内部单元格
               mappedRow.push({
-                key: cellValue.toUpperCase(),
-                color: cellValue.toUpperCase(),
+                key: normalizedCellValue,
+                color: normalizedCellValue,
                 isExternal: false
               });
             }


### PR DESCRIPTION
## Summary
- preserve `TRANSPARENT` CSV cells as the app's internal transparent cell data
- keep external cells transparent when generating the synthetic PNG used after CSV import
- exclude external cells from completion-card bead totals and thumbnails

Fixes #13

## Testing
- npm run lint
- npm run build
- git diff --check